### PR TITLE
Input detection patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # RHMPatch
 A game and file-system redirection patch for Rhythm Heaven Megamix (US version) for 3DS.
 
+## Building
+Install armips, place an unmodified code.bin as "original.bin", then run `armips asm/main.s`. You'll find the patched code.bin, now make an IPS patch from the files, and you're done!
+
 ## Credits
 - Original patches by Neobeo
 - Gate game prologue jingle patch + custom input detection patch by patataofcourse

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A game and file-system redirection patch for Rhythm Heaven Megamix (US version) 
 
 ## Credits
 - Original patches by Neobeo
-- Gate game prologue jingle patch by patataofcourse.
+- Gate game prologue jingle patch + custom input detection patch by patataofcourse

--- a/asm/custom_cmds.s
+++ b/asm/custom_cmds.s
@@ -1,0 +1,107 @@
+; Jumptable for custom commands
+
+common_cmd_default  equ 0x0025c3c0
+common_cmd_return   equ 0x002613cc
+
+cmd_amount equ 1
+
+.org common_cmd_default
+    b jt_switchcase
+
+.org pr_end
+
+jt_switchcase:
+    sub r1, #0x200
+    cmp r1, #0
+    blt common_cmd_return
+    cmp r1, cmd_amount
+    ldrcc pc, [pc, r1, lsl #2] ; since jt_table is right there
+    b common_cmd_return
+jt_table:
+    .word input_command
+jt_end:
+
+; Input checker command
+
+cmd_1f_offset       equ 0x0025c440
+
+gSaveData           equ 0x0054d350
+gInputManager       equ 0x0054eed0
+
+.org cmd_1f_offset
+    .dw input_command
+
+.org jt_end
+
+; r2 - special arg / arg0
+; r3 - cmd args
+; r6 - game state
+
+input_command:
+    cmp r2, #2
+    bhi in_null
+    bcc in_getinput
+    
+    ; 0x200<2>: get simple tap vs buttons mode
+    push {r0, r1, r3}
+
+    ; loads from save
+    ldr r0, =gSaveData
+    ldr r0, [r0]
+
+    ; 0x2dc8 (gSaveData->fileData + fileData.isSimpleTap)
+    mov r1, #0xb7
+    lsl r1, r1, #6
+    add r1, r1, #8
+
+    ; 0x1648 (sizeof(individual save))
+    mov r2, #0x59
+    lsl r2, r2, #6
+    add r2, r2, #8
+    
+    ; 0x7560 (gSaveData->currentFile)
+    mov r3, #0x75
+    lsl r3, r3, #8
+    add r3, #0x60
+
+    ; final offset: gSaveData->fileData[gSaveData->currentFile].isSimpleTap
+    ldr r3, [r0, r3]
+    mul r2, r2, r3
+    add r2, r2, r1
+    ldrb r2, [r0, r2]
+
+    pop {r0, r1, r3}
+in_getinput:
+    ldr r0, =gInputManager
+    ldr r0, [r0]
+    cmp r2, #1
+    bhi in_touch
+
+    ; 0x200<0>: check for button input at specified bit
+    ; don't shift by 32 bits or more, that'll always be 0
+    ldr r1, [r3] ; args[0]
+    cmp r1, #0x20
+    bcs in_null
+
+    ; load input data (u32 bitflags) @ gInputManager->unk4->unk4
+    ldr r0, [r0, #4]
+    ldr r0, [r0, #4]
+
+    ; set condvar to bit number args[0]
+    lsr r0, r0, r1
+    and r0, r0, #1
+    str r0, [r6, #0x20]
+    b common_cmd_return
+in_touch:
+    ; 0x200<1>: check for touchscreen input @ gInputManager->unk8->unkC
+    ldr r0, [r0, #8]
+    ldrb r0, [r0, #0xc]
+    str r0, [r6, #0x20]
+    b common_cmd_return
+in_null:
+    ; set condvar to 0
+    mov r0, #0
+    str r0, [r6, #0x20]
+    b common_cmd_return
+
+.pool

--- a/asm/custom_cmds.s
+++ b/asm/custom_cmds.s
@@ -3,7 +3,7 @@
 common_cmd_default  equ 0x0025c3c0
 common_cmd_return   equ 0x002613cc
 
-cmd_amount equ 1
+cmd_amount equ 2
 
 .org common_cmd_default
     b jt_switchcase
@@ -19,15 +19,29 @@ jt_switchcase:
     b common_cmd_return
 jt_table:
     .word input_command
+    .word version_command
 jt_end:
+
+; Registers' values
+
+; r2 - special arg / arg0
+; r3 / r5 - cmd args
+; r6 - game state
+
+; 0x201 - Quick version check
+version_command:
+    cmp r2, #0
+    strne r0, [r6, #0x20]
+    bne common_cmd_return
+
+    mov r0, MAJOR_VERSION * 0x100
+    add r0, r0, MINOR_VERSION
+    str r0, [r6, #0x20]
+    b common_cmd_return
 
 ; 0x200 - Input checker command
 gSaveData           equ 0x0054d350
 gInputManager       equ 0x0054eed0
-
-; r2 - special arg / arg0
-; r3 - cmd args
-; r6 - game state
 
 input_command:
     cmp r2, #2

--- a/asm/custom_cmds.s
+++ b/asm/custom_cmds.s
@@ -21,17 +21,9 @@ jt_table:
     .word input_command
 jt_end:
 
-; Input checker command
-
-cmd_1f_offset       equ 0x0025c440
-
+; 0x200 - Input checker command
 gSaveData           equ 0x0054d350
 gInputManager       equ 0x0054eed0
-
-.org cmd_1f_offset
-    .dw input_command
-
-.org jt_end
 
 ; r2 - special arg / arg0
 ; r3 - cmd args

--- a/asm/main.s
+++ b/asm/main.s
@@ -6,8 +6,16 @@
 MAJOR_VERSION   equ 1
 MINOR_VERSION   equ 3
 
+; prologue + custom command code start
+; putting it before apparently garbles the code and turns it to `b 0` fsr
+newCode         equ 0x399C00
+
 ; custom commands
 .include "asm/custom_cmds.s"
+
+.if . > 0x39A000
+.error "Custom command code too big"
+.endif
 
 openFile            equ 0x279E60 ; svc 0x32 (0x08030204)
 getSize             equ 0x2BC628 ; svc 0x32 (0x08040000)
@@ -231,7 +239,6 @@ sdPath: .asciiz "_:/rhmm"
 ; Prologue jingle patch
 
 gateJingleFunc  equ 0x32D678
-newCode         equ 0x399ADC
 prologueJingles equ 0x52C9B8
 
 .org gateJingleFunc

--- a/asm/main.s
+++ b/asm/main.s
@@ -231,7 +231,7 @@ sdPath: .asciiz "_:/rhmm"
 ; Prologue jingle patch
 
 gateJingleFunc  equ 0x32D678
-newCode         equ 0x399F00
+newCode         equ 0x399ADC
 prologueJingles equ 0x52C9B8
 
 .org gateJingleFunc

--- a/asm/main.s
+++ b/asm/main.s
@@ -3,6 +3,9 @@
 .arm.little
 .open "original.bin", "code.bin", 0x100000
 
+; custom commands
+.include "asm/custom_cmds.s"
+
 openFile            equ 0x279E60 ; svc 0x32 (0x08030204)
 getSize             equ 0x2BC628 ; svc 0x32 (0x08040000)
 readFile            equ 0x2BC544 ; svc 0x32 (0x080200C2)
@@ -225,7 +228,7 @@ sdPath: .asciiz "_:/rhmm"
 ; Prologue jingle patch
 
 gateJingleFunc  equ 0x32D678
-newCode         equ 0x399F00
+newCode         equ 0x399ADC
 prologueJingles equ 0x52C9B8
 
 .org gateJingleFunc
@@ -253,97 +256,5 @@ pr_label3:
     bx lr
 pr_nf: .asciiz "NotFoundAac"
 pr_end:
-
-; Input checker command
-
-cmd_1f_offset       equ 0x0025c440
-cmd_cmn_return      equ 0x002613cc
-
-gSaveData           equ 0x0054d350
-gInputManager       equ 0x0054eed0
-
-; unknown functionality, commenting for now
-
-; gInputCheckManager  equ 0x0054ef40
-; func_00277e78       equ 0x00277e78 ; checks if a struct member is a specific function
-; func_00252f1c       equ 0x00252f1c ; checks if said struct member is another specific function
-
-.org cmd_1f_offset
-    .dw in_newcode
-
-.org pr_end
-
-; r2 - special arg / arg0
-; r3 - cmd args
-; r6 - game state
-
-in_newcode:
-    cmp r2, #2
-    bhi in_null
-    bcc in_getinput
-    
-    ; 0x1F<2>: get simple tap vs buttons mode
-    push {r0, r1, r3}
-
-    ; loads from save
-    ldr r0, =gSaveData
-    ldr r0, [r0]
-
-    ; 0x2dc8 (gSaveData->fileData + fileData.isSimpleTap)
-    mov r1, #0xb7
-    lsl r1, r1, #6
-    add r1, r1, #8
-
-    ; 0x1648 (sizeof(individual save))
-    mov r2, #0x59
-    lsl r2, r2, #6
-    add r2, r2, #8
-    
-    ; 0x7560 (gSaveData->currentFile)
-    mov r3, #0x75
-    lsl r3, r3, #8
-    add r3, #0x60
-
-    ; final offset: gSaveData->fileData[gSaveData->currentFile].isSimpleTap
-    ldr r3, [r0, r3]
-    mul r2, r2, r3
-    add r2, r2, r1
-    ldrb r2, [r0, r2]
-
-    pop {r0, r1, r3}
-in_getinput:
-    ldr r0, =gInputManager
-    ldr r0, [r0]
-    cmp r2, #1
-    bhi in_touch
-
-    ; 0x1F<0>: check for button input at specified bit
-    ; don't shift by 32 bits or more, that'll always be 0
-    ldr r1, [r3] ; args[0]
-    cmp r1, #0x20
-    bcs in_null
-
-    ; load input data (u32 bitflags) @ gInputManager->unk4->unk4
-    ldr r0, [r0, #4]
-    ldr r0, [r0, #4]
-
-    ; set condvar to bit number args[0]
-    lsr r0, r0, r1
-    and r0, r0, #1
-    str r0, [r6, #0x20]
-    b cmd_cmn_return
-in_touch:
-    ; 0x1F<1>: check for touchscreen input @ gInputManager->unk8->unkC
-    ldr r0, [r0, #8]
-    ldrb r0, [r0, #0xc]
-    str r0, [r6, #0x20]
-    b cmd_cmn_return
-in_null:
-    ; set condvar to 0
-    mov r0, #0
-    str r0, [r6, #0x20]
-    b cmd_cmn_return
-
-.pool
 
 .close

--- a/asm/main.s
+++ b/asm/main.s
@@ -3,6 +3,9 @@
 .arm.little
 .open "original.bin", "code.bin", 0x100000
 
+MAJOR_VERSION   equ 1
+MINOR_VERSION   equ 3
+
 ; custom commands
 .include "asm/custom_cmds.s"
 

--- a/patch.asm
+++ b/patch.asm
@@ -263,27 +263,31 @@ input_struct    equ 0x0054eed0
 .org cmd_1f_offset
     .dw in_newcode
 
+; r2 - special arg / arg0
+; r3 - cmd args
+; r6 - current state
+
 .org pr_end
 in_newcode:
+    ; don't shift by 32 bits or more, that'll always be 0
     ldr r1, [r3]
     cmp r1, #0x20
     blt in_label1
 in_return:
+    ; set condvar to 0
     mov r0, #0
     str r0, [r6, #0x20]
     b cmd_cmn_return
 in_label1:
+    ; load input data (u32 bitflags)
     ldr r0, =input_struct
     ldr r0, [r0]
     ldr r0, [r0, #4]
-    cmp r2, #2
-    bgt in_return
-    ldreq r0, [r0, #0xC]
-    beq in_label2
-    cmp r2, #1
-    ldreq r0, [r0, #0x8]
-    ldrne r0, [r0, #0x4]
+    cmp r2, #0
+    bne in_return
+    ldr r0, [r0, #0x4]
 in_label2:
+    ; set condvar to bit number args[0]
     lsr r0, r0, r1
     and r0, r0, #1
     str r0, [r6, #0x20]

--- a/patch.asm
+++ b/patch.asm
@@ -314,7 +314,7 @@ in_newcode:
 in_getinput:
     ldr r0, =gInputManager
     ldr r0, [r0]
-    cmp r2, #1
+    cmp r2, #0
     bhi in_touch
 
     ; 0x1F<0>: check for button input at specified bit

--- a/patch.asm
+++ b/patch.asm
@@ -254,4 +254,41 @@ pr_label3:
 pr_nf: .asciiz "NotFoundAac"
 pr_end:
 
+; Input checker command
+
+cmd_1f_offset   equ 0x0025c440
+cmd_cmn_return  equ 0x002613cc
+input_struct    equ 0x0054eed0
+
+.org cmd_1f_offset
+    .dw in_newcode
+
+.org pr_end
+in_newcode:
+    ldr r1, [r3]
+    cmp r1, #0x20
+    blt in_label1
+in_return:
+    mov r0, #0
+    str r0, [r6, #0x20]
+    b cmd_cmn_return
+in_label1:
+    ldr r0, =input_struct
+    ldr r0, [r0]
+    ldr r0, [r0, #4]
+    cmp r2, #2
+    bgt in_return
+    ldreq r0, [r0, #0xC]
+    beq in_label2
+    cmp r2, #1
+    ldreq r0, [r0, #0x8]
+    ldrne r0, [r0, #0x4]
+in_label2:
+    lsr r0, r0, r1
+    and r0, r0, #1
+    str r0, [r6, #0x20]
+    b cmd_cmn_return
+
+.pool
+
 .close

--- a/patch.asm
+++ b/patch.asm
@@ -256,40 +256,91 @@ pr_end:
 
 ; Input checker command
 
-cmd_1f_offset   equ 0x0025c440
-cmd_cmn_return  equ 0x002613cc
-input_struct    equ 0x0054eed0
+cmd_1f_offset       equ 0x0025c440
+cmd_cmn_return      equ 0x002613cc
+
+gSaveData           equ 0x0054d350
+gInputManager       equ 0x0054eed0
+
+; unknown functionality, commenting for now
+
+; gInputCheckManager  equ 0x0054ef40
+; func_00277e78       equ 0x00277e78 ; checks if a struct member is a specific function
+; func_00252f1c       equ 0x00252f1c ; checks if said struct member is another specific function
 
 .org cmd_1f_offset
     .dw in_newcode
 
+.org pr_end
+
 ; r2 - special arg / arg0
 ; r3 - cmd args
-; r6 - current state
+; r6 - game state
 
-.org pr_end
 in_newcode:
-    ; don't shift by 32 bits or more, that'll always be 0
-    ldr r1, [r3]
-    cmp r1, #0x20
-    blt in_label1
-in_return:
-    ; set condvar to 0
-    mov r0, #0
-    str r0, [r6, #0x20]
-    b cmd_cmn_return
-in_label1:
-    ; load input data (u32 bitflags)
-    ldr r0, =input_struct
+    cmp r2, #2
+    bhi in_null
+    bcc in_getinput
+    
+    ; 0x1F<2>: get simple tap vs buttons mode
+    push {r0, r1, r3}
+
+    ; loads from save
+    ldr r0, =gSaveData
     ldr r0, [r0]
+
+    ; 0x2dc8 (gSaveData->fileData + fileData.isSimpleTap)
+    mov r1, #0xb7
+    lsl r1, r1, #6
+    add r1, r1, #8
+
+    ; 0x1648 (sizeof(individual save))
+    mov r2, #0x59
+    lsl r2, r2, #6
+    add r2, r2, #8
+    
+    ; 0x7560 (gSaveData->currentFile)
+    mov r3, #0x75
+    lsl r3, r3, #8
+    add r3, #0x60
+
+    ; final offset: gSaveData->fileData[gSaveData->currentFile].isSimpleTap
+    ldr r3, [r0, r3]
+    mul r2, r2, r3
+    add r2, r2, r1
+    ldrb r2, [r0, r2]
+
+    pop {r0, r1, r3}
+in_getinput:
+    ldr r0, =gInputManager
+    ldr r0, [r0]
+    cmp r2, #1
+    bhi in_touch
+
+    ; 0x1F<0>: check for button input at specified bit
+    ; don't shift by 32 bits or more, that'll always be 0
+    ldr r1, [r3] ; args[0]
+    cmp r1, #0x20
+    bcs in_null
+
+    ; load input data (u32 bitflags) @ gInputManager->unk4->unk4
     ldr r0, [r0, #4]
-    cmp r2, #0
-    bne in_return
-    ldr r0, [r0, #0x4]
-in_label2:
+    ldr r0, [r0, #4]
+
     ; set condvar to bit number args[0]
     lsr r0, r0, r1
     and r0, r0, #1
+    str r0, [r6, #0x20]
+    b cmd_cmn_return
+in_touch:
+    ; 0x1F<1>: check for touchscreen input @ gInputManager->unk8->unkC
+    ldr r0, [r0, #8]
+    ldrb r0, [r0, #0xc]
+    str r0, [r6, #0x20]
+    b cmd_cmn_return
+in_null:
+    ; set condvar to 0
+    mov r0, #0
     str r0, [r6, #0x20]
     b cmd_cmn_return
 


### PR DESCRIPTION
This adds the following:
- A jump table for custom common tickflow commands starting at 0x200
- Command 0x200: detect if a specific button is being pressed, if the screen is being tapped, or either or depending on whether buttons or simple tap mode is on
- Command 0x201: set the condvar to the version of RHMPatch (example: for 1.3, the next version, sets it to 0x103)

You can see detailed docs for the new commands at https://pastebin.com/0AQyTNP0

Some extra stuff:
- a bit of restructuring: the main patch is at `asm/main.s` rather than `patch.asm`, and it also includes file `asm/custom_cmds.s`
- changes newCode offset (also used for the prologue jingle patch) from `0x399F00` to `0x399C00` (it could theoretically start at `ADC`, but that turns a lot of instructions into `b 0` fsr, might be fixable with an exheader patch?)
- adds a conditional to detect if the code set for the newCode area (up to `0x39A000`) is bigger than the free section itself

This PR is a draft for now because IMO it still needs its fair share of testing- I'll give it at least a week in case anything pops up.