### PR TITLE
Fan Club clap on jump patch

### DIFF
--- a/asm/main.s
+++ b/asm/main.s
@@ -272,4 +272,30 @@ pr_label3:
 pr_nf: .asciiz "NotFoundAac"
 pr_end:
 
+; Fan Club jumpclap patch
+; Conditional to 0x2B setup being 0xF
+
+getSpecialVer equ 0x00257a78
+
+FanClub__doClap equ 0x003453f8
+FanClub__noClap equ 0x0034540c
+
+.org 0x003453e4
+    b FanClub__clapPatch
+
+FanClub__clapPatch:
+    mov r0, #0x15
+    bl getSpecialVer
+    cmp r0, #0xf
+    ldrne r0, [r4, #0x80]
+    ldrne r1, [r0, #0xa4]
+    ldrbne r1, [r1, #0x30]
+    cmpne r1, #0
+    beq FanClub__doClap
+    bne FanClub__noClap
+
+.if . > 0x0020ade8
+.error "extra custom code too big"
+.endif
+
 .close


### PR DESCRIPTION
For recreations!

When Fan Club's scene setup (0x2B command) is set to 0xF, clap inputs while the monkey is recovering from a jump will still go through.